### PR TITLE
Remove unneeded CSS

### DIFF
--- a/components/com_apps/css/apps.css
+++ b/components/com_apps/css/apps.css
@@ -1,15 +1,3 @@
-.row-fluid .sidebar, .row-fluid .extensions {
-    float: left;
-}
-
-.row-fluid .sidebar {
-    width: 25%;
-}
-
-.row-fluid .extensions {
-    width: 75%;
-}
-
 .com-apps-container .thumbnail .item-image img {
 	max-width: 100%;
 	max-height: 90%;


### PR DESCRIPTION
Based on https://github.com/joomla-extensions/install-from-web-server/commit/e66e9c60c986318ce317b5fb4cf897b8fc59814b , that CSS isn't needed. Only the recently added CSS for images is.