### PR TITLE
Convert all JED ext images to resizeDown version

### DIFF
--- a/components/com_apps/models/base.php
+++ b/components/com_apps/models/base.php
@@ -72,7 +72,7 @@ class AppsModelBase extends JModelList
 		$image = str_replace('http://extensions.joomla.org/', $cdn, $image);
 		
 		// Replace API Image path with resizeDown path
-		$image = preg_replace('#logo/(.*)\.#', '$1' . '_resizeDown302px133px16.', $image, 1);
+		$image = preg_replace('#(logo|images)/(.*)\.#', '$2' . '_resizeDown302px133px16.', $image, 1);
 
 		return $image;
 	}


### PR DESCRIPTION
I missed some logos with the /images/ path. This PR caches both variants.

e.g.
http://extensionscdn.joomla.org/cache/fab_image/images/53140.png
should become:
http://extensionscdn.joomla.org/cache/fab_image/53140_resizeDown302px133px16.png

and:
http://extensionscdn.joomla.org/cache/fab_image/logo/548ff93e7bdd0.png
should become:
http://extensionscdn.joomla.org/cache/fab_image/548ff93e7bdd0_resizeDown302px133px16.png