### PR TITLE
Misc. improvements in HTTP connections and caching

### DIFF
--- a/components/com_apps/helpers/update.php
+++ b/components/com_apps/helpers/update.php
@@ -1,0 +1,515 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Updater
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Update class. It is used by JUpdater::update() to install an update. Use JUpdater::findUpdates() to find updates for
+ * an extension.
+ *
+ * @since  11.1
+ */
+class JUpdate extends JObject
+{
+	/**
+	 * Update manifest `<name>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $name;
+
+	/**
+	 * Update manifest `<description>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $description;
+
+	/**
+	 * Update manifest `<element>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $element;
+
+	/**
+	 * Update manifest `<type>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $type;
+
+	/**
+	 * Update manifest `<version>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $version;
+
+	/**
+	 * Update manifest `<infourl>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $infourl;
+
+	/**
+	 * Update manifest `<client>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $client;
+
+	/**
+	 * Update manifest `<group>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $group;
+
+	/**
+	 * Update manifest `<downloads>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $downloads;
+
+	/**
+	 * Update manifest `<tags>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $tags;
+
+	/**
+	 * Update manifest `<maintainer>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $maintainer;
+
+	/**
+	 * Update manifest `<maintainerurl>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $maintainerurl;
+
+	/**
+	 * Update manifest `<category>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $category;
+
+	/**
+	 * Update manifest `<relationships>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $relationships;
+
+	/**
+	 * Update manifest `<targetplatform>` element
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $targetplatform;
+
+	/**
+	 * Extra query for download URLs
+	 *
+	 * @var    string
+	 * @since  13.1
+	 */
+	protected $extra_query;
+
+	/**
+	 * Resource handle for the XML Parser
+	 *
+	 * @var    resource
+	 * @since  12.1
+	 */
+	protected $xmlParser;
+
+	/**
+	 * Element call stack
+	 *
+	 * @var    array
+	 * @since  12.1
+	 */
+	protected $stack = array('base');
+
+	/**
+	 * Unused state array
+	 *
+	 * @var    array
+	 * @since  12.1
+	 */
+	protected $stateStore = array();
+
+	/**
+	 * Object containing the current update data
+	 *
+	 * @var    stdClass
+	 * @since  12.1
+	 */
+	protected $currentUpdate;
+
+	/**
+	 * Object containing the latest update data
+	 *
+	 * @var    stdClass
+	 * @since  12.1
+	 */
+	protected $latest;
+
+	/**
+	 * The minimum stability required for updates to be taken into account. The possible values are:
+	 * 0	dev			Development snapshots, nightly builds, pre-release versions and so on
+	 * 1	alpha		Alpha versions (work in progress, things are likely to be broken)
+	 * 2	beta		Beta versions (major functionality in place, show-stopper bugs are likely to be present)
+	 * 3	rc			Release Candidate versions (almost stable, minor bugs might be present)
+	 * 4	stable		Stable versions (production quality code)
+	 *
+	 * @var    int
+	 * @since  14.1
+	 *
+	 * @see    JUpdater
+	 */
+	protected $minimum_stability = JUpdater::STABILITY_STABLE;
+
+	/**
+	 * Gets the reference to the current direct parent
+	 *
+	 * @return  object
+	 *
+	 * @since   11.1
+	 */
+	protected function _getStackLocation()
+	{
+		return implode('->', $this->stack);
+	}
+
+	/**
+	 * Get the last position in stack count
+	 *
+	 * @return  string
+	 *
+	 * @since   11.1
+	 */
+	protected function _getLastTag()
+	{
+		return $this->stack[count($this->stack) - 1];
+	}
+
+	/**
+	 * XML Start Element callback
+	 *
+	 * @param   object  $parser  Parser object
+	 * @param   string  $name    Name of the tag found
+	 * @param   array   $attrs   Attributes of the tag
+	 *
+	 * @return  void
+	 *
+	 * @note    This is public because it is called externally
+	 * @since   11.1
+	 */
+	public function _startElement($parser, $name, $attrs = array())
+	{
+		$this->stack[] = $name;
+		$tag           = $this->_getStackLocation();
+
+		// Reset the data
+		if (isset($this->$tag))
+		{
+			$this->$tag->_data = '';
+		}
+
+		switch ($name)
+		{
+			// This is a new update; create a current update
+			case 'UPDATE':
+				$this->currentUpdate = new stdClass;
+				break;
+
+			// Don't do anything
+			case 'UPDATES':
+				break;
+
+			// For everything else there's...the default!
+			default:
+				$name = strtolower($name);
+
+				if (!isset($this->currentUpdate->$name))
+				{
+					$this->currentUpdate->$name = new stdClass;
+				}
+
+				$this->currentUpdate->$name->_data = '';
+
+				foreach ($attrs as $key => $data)
+				{
+					$key = strtolower($key);
+					$this->currentUpdate->$name->$key = $data;
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Callback for closing the element
+	 *
+	 * @param   object  $parser  Parser object
+	 * @param   string  $name    Name of element that was closed
+	 *
+	 * @return  void
+	 *
+	 * @note    This is public because it is called externally
+	 * @since   11.1
+	 */
+	public function _endElement($parser, $name)
+	{
+		array_pop($this->stack);
+
+		switch ($name)
+		{
+			// Closing update, find the latest version and check
+			case 'UPDATE':
+				$product = strtolower(JFilterInput::getInstance()->clean(JVersion::PRODUCT, 'cmd'));
+
+				// Support for the min_dev_level and max_dev_level attributes is deprecated, a regexp should be used instead
+				if (isset($this->currentUpdate->targetplatform->min_dev_level) || isset($this->currentUpdate->targetplatform->max_dev_level))
+				{
+					JLog::add(
+						'Support for the min_dev_level and max_dev_level attributes of an update\'s <targetplatform> tag is deprecated and'
+						. ' will be removed in 4.0. The full version should be specified in the version attribute and may optionally be a regexp.',
+						JLog::WARNING,
+						'deprecated'
+					);
+				}
+
+				/*
+				 * Check that the product matches and that the version matches (optionally a regexp)
+				 *
+				 * Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
+				 */
+				if (isset($this->currentUpdate->targetplatform->name)
+					&& $product == $this->currentUpdate->targetplatform->name
+					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
+					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level))
+					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
+					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level))
+					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
+				{
+					$phpMatch = false;
+
+					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
+					if (!isset($this->currentUpdate->php_minimum) || version_compare(PHP_VERSION, $this->currentUpdate->php_minimum->_data, '>='))
+					{
+						$phpMatch = true;
+					}
+
+					$dbMatch = false;
+
+					// Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
+					if (isset($this->currentUpdate->supported_databases))
+					{
+						$db           = JFactory::getDbo();
+						$dbType       = strtolower($db->getServerType());
+						$dbVersion    = $db->getVersion();
+						$supportedDbs = $this->currentUpdate->supported_databases;
+
+						// Do we have a entry for the database?
+						if (isset($supportedDbs->$dbType))
+						{
+							$minumumVersion = $supportedDbs->$dbType;
+							$dbMatch        = version_compare($dbVersion, $minumumVersion, '>=');
+						}
+					}
+					else
+					{
+						// Set to true if the <supported_databases> tag is not set
+						$dbMatch = true;
+					}
+
+					// Check minimum stability
+					$stabilityMatch = true;
+
+					if (isset($this->currentUpdate->stability) && ($this->currentUpdate->stability < $this->minimum_stability))
+					{
+						$stabilityMatch = false;
+					}
+
+					if ($phpMatch && $stabilityMatch && $dbMatch)
+					{
+						if (isset($this->latest))
+						{
+							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>') == 1)
+							{
+								$this->latest = $this->currentUpdate;
+							}
+						}
+						else
+						{
+							$this->latest = $this->currentUpdate;
+						}
+					}
+				}
+				break;
+			case 'UPDATES':
+				// If the latest item is set then we transfer it to where we want to
+				if (isset($this->latest))
+				{
+					foreach (get_object_vars($this->latest) as $key => $val)
+					{
+						$this->$key = $val;
+					}
+
+					unset($this->latest);
+					unset($this->currentUpdate);
+				}
+				elseif (isset($this->currentUpdate))
+				{
+					// The update might be for an older version of j!
+					unset($this->currentUpdate);
+				}
+				break;
+		}
+	}
+
+	/**
+	 * Character Parser Function
+	 *
+	 * @param   object  $parser  Parser object.
+	 * @param   object  $data    The data.
+	 *
+	 * @return  void
+	 *
+	 * @note    This is public because its called externally.
+	 * @since   11.1
+	 */
+	public function _characterData($parser, $data)
+	{
+		$tag = $this->_getLastTag();
+
+		// Throw the data for this item together
+		$tag = strtolower($tag);
+
+		if ($tag == 'tag')
+		{
+			$this->currentUpdate->stability = $this->stabilityTagToInteger((string) $data);
+
+			return;
+		}
+
+		if (isset($this->currentUpdate->$tag))
+		{
+			$this->currentUpdate->$tag->_data .= $data;
+		}
+	}
+
+	/**
+	 * Loads an XML file from a URL.
+	 *
+	 * @param   string  $url                The URL.
+	 * @param   int     $minimum_stability  The minimum stability required for updating the extension {@see JUpdater}
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   11.1
+	 */
+	public function loadFromXml($url, $minimum_stability = JUpdater::STABILITY_STABLE)
+	{
+		$version    = new JVersion;
+		$httpOption = new Registry;
+		$httpOption->set('userAgent', $version->getUserAgent('Joomla', true, false));
+
+		try
+		{
+			$http = JHttpFactory::getHttp($httpOption);
+			$response = $http->get($url);
+		}
+		catch (RuntimeException $e)
+		{
+			$response = null;
+		}
+
+		if ($response === null || $response->code !== 200)
+		{
+			// TODO: Add a 'mark bad' setting here somehow
+			JLog::add(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), JLog::WARNING, 'jerror');
+
+			return false;
+		}
+
+		$this->minimum_stability = $minimum_stability;
+
+		$this->xmlParser = xml_parser_create('');
+		xml_set_object($this->xmlParser, $this);
+		xml_set_element_handler($this->xmlParser, '_startElement', '_endElement');
+		xml_set_character_data_handler($this->xmlParser, '_characterData');
+
+		if (!xml_parse($this->xmlParser, $response->body))
+		{
+			JLog::add(
+				sprintf(
+					'XML error: %s at line %d', xml_error_string(xml_get_error_code($this->xmlParser)),
+					xml_get_current_line_number($this->xmlParser)
+				),
+				JLog::WARNING, 'updater'
+			);
+
+			return false;
+		}
+
+		xml_parser_free($this->xmlParser);
+
+		return true;
+	}
+
+	/**
+	 * Converts a tag to numeric stability representation. If the tag doesn't represent a known stability level (one of
+	 * dev, alpha, beta, rc, stable) it is ignored.
+	 *
+	 * @param   string  $tag  The tag string, e.g. dev, alpha, beta, rc, stable
+	 *
+	 * @return  integer
+	 *
+	 * @since   3.4
+	 */
+	protected function stabilityTagToInteger($tag)
+	{
+		$constant = 'JUpdater::STABILITY_' . strtoupper($tag);
+
+		if (defined($constant))
+		{
+			return constant($constant);
+		}
+
+		return JUpdater::STABILITY_STABLE;
+	}
+}

--- a/components/com_apps/models/base.php
+++ b/components/com_apps/models/base.php
@@ -82,6 +82,9 @@ class AppsModelBase extends JModelList
 		return $categoryData;
 	}
 
+	/**
+	 * @return  JHttp
+	 */
 	public function getHttpClient()
 	{
 		$version = new JVersion;

--- a/components/com_apps/models/category.php
+++ b/components/com_apps/models/category.php
@@ -134,10 +134,12 @@ class AppsModelCategory extends JModelList
 		return $this->_parent;
 	}
 
+	/**
+	 * @return  bool|AppsModelBase
+	 */
 	private function getBaseModel()
 	{
-		$base_model = JModelLegacy::getInstance('Base', 'AppsModel');
-		return $base_model;
+		return JModelLegacy::getInstance('Base', 'AppsModel');
 	}
 
 	private function getCatID()

--- a/components/com_apps/models/dashboard.php
+++ b/components/com_apps/models/dashboard.php
@@ -135,7 +135,7 @@ class AppsModelDashboard extends JModelList
 	}
 
 	/**
-	 * @return bool|AppsModelBase
+	 * @return  bool|AppsModelBase
 	 */
 	private function getBaseModel()
 	{

--- a/components/com_apps/models/dashboard.php
+++ b/components/com_apps/models/dashboard.php
@@ -262,7 +262,6 @@ class AppsModelDashboard extends JModelList
 		}
 
 		return array_merge($extensions[0], $extensions[1]);
-
 	}
 
 	public function getCount()
@@ -271,7 +270,7 @@ class AppsModelDashboard extends JModelList
 	}
 
 	/**
-	 * Fetches the category data from the JED
+	 * Fetches the dashboard extensions from the JED
 	 *
 	 * @param   JUri  $uri  The URI to request data from
 	 *

--- a/components/com_apps/models/dashboard.php
+++ b/components/com_apps/models/dashboard.php
@@ -172,59 +172,91 @@ class AppsModelDashboard extends JModelList
 
 	public function getExtensions()
 	{
-		// Get catid, search filter, order column, order direction
-		$cache           = JFactory::getCache();
-		$cache->setCaching( 1 );
-		$http            = new JHttp;
-		$http->setOption('timeout', 60);
+		/** @var JCacheControllerCallback $cache */
+		$cache = JFactory::getCache('com_apps', 'callback');
+
+		// These calls are always cached
+		$cache->setCaching(true);
+
+		// Extract some default values from the component params
 		$componentParams = JComponentHelper::getParams('com_apps');
-		$api_url         = new JUri;
-		$default_limit   = $componentParams->get('default_limit', 8);
-		$input           = new JInput;
-		$catid           = $input->get('id', null, 'int');
-		$order           = $input->get('ordering', $this->getOrderBy());
-		$orderCol        = $this->state->get('list.ordering', $order);
-		$orderDirn       = $orderCol == 'core_title' ? 'ASC' : 'DESC';
-		$release         = preg_replace('/[^\d]/', '', base64_decode($input->get('release', '', 'base64')));
-		$limitstart      = $input->get('limitstart', 0, 'int');
-		$limit           = $input->get('limit', $default_limit, 'int');
-		$dashboard_limit = $componentParams->get('extensions_perrow') * 6; // 6 rows of extensions
-		$search          = str_replace('_', ' ', urldecode(trim($input->get('filter_search', null))));
 
-		$release = intval($release / 5) * 5;
+		$defaultLimit = $componentParams->get('default_limit', 8);
 
-		$api_url->setScheme('http');
-		$api_url->setHost('extensions.joomla.org/index.php');
-		$api_url->setvar('option', 'com_jed');
-		$api_url->setvar('controller', 'filter');
-		$api_url->setvar('view', 'extension');
-		$api_url->setvar('format', 'json');
-		$api_url->setvar('limit', $limit);
-		$api_url->setvar('limitstart', $limitstart);
-		$api_url->setvar('filter[approved]', '1');
-		$api_url->setvar('filter[published]', '1');
-		$api_url->setvar('extend', '0');
-		$api_url->setvar('order', $orderCol);
-		$api_url->setvar('dir', $orderDirn);
+		// Extract params from the request
+		$input = JFactory::getApplication()->input;
 
-		if ($search) {
-			$api_url->setvar('searchall', urlencode($search));
+		$limit      = $input->getInt('limit', $defaultLimit);
+		$limitstart = $input->getInt('limitstart', 0);
+		$order      = $input->get('ordering', $this->getOrderBy());
+		$search     = str_replace('_', ' ', urldecode(trim($input->get('filter_search', null))));
+
+		// Params based on the model state
+		$orderCol  = $this->getState('list.ordering', $order);
+		$orderDirn = $orderCol == 'core_title' ? 'ASC' : 'DESC';
+
+		// Build the request URL here, since this will vary based on params we will use the URL as part of our cache key
+		$url = new JUri;
+
+		$url->setScheme('https');
+		$url->setHost('extensions.joomla.org');
+		$url->setPath('/index.php');
+		$url->setVar('option', 'com_jed');
+		$url->setVar('controller', 'filter');
+		$url->setVar('view', 'extension');
+		$url->setVar('format', 'json');
+		$url->setVar('limit', $limit);
+		$url->setVar('limitstart', $limitstart);
+		$url->setVar('filter[approved]', '1');
+		$url->setVar('filter[published]', '1');
+		$url->setVar('extend', '0');
+		$url->setVar('order', $orderCol);
+		$url->setVar('dir', $orderDirn);
+
+		if ($search)
+		{
+			$url->setVar('searchall', urlencode($search));
 		}
 
-		$extensions_json = $cache->call(array($http, 'get'), $api_url);
+		try
+		{
+			// We explicitly define our own ID to keep JCache from calculating it separately
+			$items = $cache->get(array($this, 'fetchDashboardExtensions'), array($url), md5(__METHOD__ . $url->toString()));
+		}
+		catch (JCacheException $e)
+		{
+			// Cache failure, let's try an HTTP request without caching
+			$items = $this->fetchDashboardExtensions($url);
+		}
+		catch (RuntimeException $e)
+		{
+			// Other failure, this isn't good
+			JLog::add(
+				'Could not retrieve dashboard extension data from the JED: ' . $e->getMessage(),
+				JLog::ERROR,
+				'com_apps'
+			);
 
-		$items = json_decode($extensions_json->body);
-		$items = $items->data;
+			// Throw a "sanitised" Exception but nest the caught Exception for debugging
+			throw new RuntimeException('Could not retrieve dashboard extension data from the JED.', $e->getCode(), $e);
+		}
+
+		$baseModel = $this->getBaseModel();
+		$items     = $items->data;
 
 		// Populate array
-		$extensions = array(0=>array(), 1=>array());
-		foreach ($items as $item) {
-			$item->image = $this->getBaseModel()->getMainImageUrl($item);
+		$extensions = array(0 => array(), 1 => array());
 
-			if ($search) {
+		foreach ($items as $item)
+		{
+			$item->image = $baseModel->getMainImageUrl($item);
+
+			if ($search)
+			{
 				$extensions[1 - $item->foundintitle][] = $item;
 			}
-			else {
+			else
+			{
 				$extensions[0][] = $item;
 			}
 		}
@@ -236,5 +268,44 @@ class AppsModelDashboard extends JModelList
 	public function getCount()
 	{
 		return $this->_total;
+	}
+
+	/**
+	 * Fetches the category data from the JED
+	 *
+	 * @param   JUri  $uri  The URI to request data from
+	 *
+	 * @return  array
+	 *
+	 * @throws  RuntimeException if the HTTP query fails
+	 */
+	public function fetchDashboardExtensions(JUri $uri)
+	{
+		try
+		{
+			$http = $this->getBaseModel()->getHttpClient();
+		}
+		catch (RuntimeException $e)
+		{
+			throw new RuntimeException('Cannot fetch HTTP client to connect to JED', $e->getCode(), $e);
+		}
+
+		$response = $http->get($uri->toString());
+
+		// Make sure we've gotten an expected good response
+		if ($response->code !== 200)
+		{
+			throw new RuntimeException('Unexpected response from the JED', $response->code);
+		}
+
+		// The body should be a JSON string, if we have issues decoding it assume we have a bad response
+		$categoryData = json_decode($response->body);
+
+		if (json_last_error())
+		{
+			throw new RuntimeException('Unexpected response from the JED, JSON could not be decoded with error: ' . json_last_error_msg(), 500);
+		}
+
+		return $categoryData;
 	}
 }

--- a/components/com_apps/models/dashboard.php
+++ b/components/com_apps/models/dashboard.php
@@ -9,6 +9,16 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
+use Joomla\CMS\Categories\Categories;
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\CMS\Uri\Uri;
+use Joomla\Registry\Registry;
+
 /**
  * This models supports retrieving lists of contact categories.
  *
@@ -16,7 +26,7 @@ defined('_JEXEC') or die;
  * @subpackage  com_apps
  * @since       1.6
  */
-class AppsModelDashboard extends JModelList
+class AppsModelDashboard extends ListModel
 {
 	/**
 	 * Model context string.
@@ -57,7 +67,7 @@ class AppsModelDashboard extends JModelList
 	 */
 	protected function populateState($ordering = null, $direction = null)
 	{
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 		$this->setState('filter.extension', $this->_extension);
 
 		// Get the parent id if defined.
@@ -102,22 +112,27 @@ class AppsModelDashboard extends JModelList
 	{
 		if (!count($this->_items))
 		{
-			$app = JFactory::getApplication();
-			$menu = $app->getMenu();
+			$app    = Factory::getApplication();
+			$menu   = $app->getMenu();
 			$active = $menu->getActive();
-			$params = new JRegistry;
+			$params = new Registry;
+
 			if ($active)
 			{
 				$params->loadString($active->params);
 			}
-			$options = array();
+
+			$options               = [];
 			$options['countItems'] = $params->get('show_cat_items_cat', 1) || !$params->get('show_empty_categories_cat', 0);
-			$categories = JCategories::getInstance('Contact', $options);
-			$this->_parent = $categories->get($this->getState('filter.parentId', 'root'));
+			$categories            = Categories::getInstance('Contact', $options);
+			$this->_parent         = $categories->get($this->getState('filter.parentId', 'root'));
+
 			if (is_object($this->_parent))
 			{
 				$this->_items = $this->_parent->getChildren();
-			} else {
+			}
+			else
+			{
 				$this->_items = false;
 			}
 		}
@@ -139,7 +154,7 @@ class AppsModelDashboard extends JModelList
 	 */
 	private function getBaseModel()
 	{
-		return JModelLegacy::getInstance('Base', 'AppsModel');
+		return BaseDatabaseModel::getInstance('Base', 'AppsModel');
 	}
 
 	private function getCatID()
@@ -149,20 +164,17 @@ class AppsModelDashboard extends JModelList
 
 	public function getCategories()
 	{
-		$base_model = $this->getBaseModel();
-		return $base_model->getCategories($this->getCatID());
+		return $this->getBaseModel()->getCategories($this->getCatID());
 	}
 
 	public function getBreadcrumbs()
 	{
-		$base_model = $this->getBaseModel();
-		return $base_model->getBreadcrumbs($this->getCatID());
+		return $this->getBaseModel()->getBreadcrumbs($this->getCatID());
 	}
 
 	public function getPluginUpToDate()
 	{
-		$base_model = $this->getBaseModel();
-		return $base_model->getPluginUpToDate();
+		return $this->getBaseModel()->getPluginUpToDate();
 	}
 
 	public function getOrderBy()
@@ -172,19 +184,19 @@ class AppsModelDashboard extends JModelList
 
 	public function getExtensions()
 	{
-		/** @var JCacheControllerCallback $cache */
-		$cache = JFactory::getCache('com_apps', 'callback');
+		/** @var \Joomla\CMS\Cache\Controller\CallbackController $cache */
+		$cache = Factory::getCache('com_apps', 'callback');
 
 		// These calls are always cached
 		$cache->setCaching(true);
 
 		// Extract some default values from the component params
-		$componentParams = JComponentHelper::getParams('com_apps');
+		$componentParams = ComponentHelper::getParams('com_apps');
 
 		$defaultLimit = $componentParams->get('default_limit', 8);
 
 		// Extract params from the request
-		$input = JFactory::getApplication()->input;
+		$input = Factory::getApplication()->input;
 
 		$limit      = $input->getInt('limit', $defaultLimit);
 		$limitstart = $input->getInt('limitstart', 0);
@@ -196,7 +208,7 @@ class AppsModelDashboard extends JModelList
 		$orderDirn = $orderCol == 'core_title' ? 'ASC' : 'DESC';
 
 		// Build the request URL here, since this will vary based on params we will use the URL as part of our cache key
-		$url = new JUri;
+		$url = new Uri;
 
 		$url->setScheme('https');
 		$url->setHost('extensions.joomla.org');
@@ -223,7 +235,7 @@ class AppsModelDashboard extends JModelList
 			// We explicitly define our own ID to keep JCache from calculating it separately
 			$items = $cache->get(array($this, 'fetchDashboardExtensions'), array($url), md5(__METHOD__ . $url->toString()));
 		}
-		catch (JCacheException $e)
+		catch (CacheExceptionInterface $e)
 		{
 			// Cache failure, let's try an HTTP request without caching
 			$items = $this->fetchDashboardExtensions($url);
@@ -231,9 +243,9 @@ class AppsModelDashboard extends JModelList
 		catch (RuntimeException $e)
 		{
 			// Other failure, this isn't good
-			JLog::add(
+			Log::add(
 				'Could not retrieve dashboard extension data from the JED: ' . $e->getMessage(),
-				JLog::ERROR,
+				Log::ERROR,
 				'com_apps'
 			);
 
@@ -272,13 +284,13 @@ class AppsModelDashboard extends JModelList
 	/**
 	 * Fetches the dashboard extensions from the JED
 	 *
-	 * @param   JUri  $uri  The URI to request data from
+	 * @param   Uri  $uri  The URI to request data from
 	 *
 	 * @return  array
 	 *
 	 * @throws  RuntimeException if the HTTP query fails
 	 */
-	public function fetchDashboardExtensions(JUri $uri)
+	public function fetchDashboardExtensions(Uri $uri)
 	{
 		try
 		{

--- a/components/com_apps/models/dashboard.php
+++ b/components/com_apps/models/dashboard.php
@@ -134,10 +134,12 @@ class AppsModelDashboard extends JModelList
 		return $this->_parent;
 	}
 
+	/**
+	 * @return bool|AppsModelBase
+	 */
 	private function getBaseModel()
 	{
-		$base_model = JModelLegacy::getInstance('Base', 'AppsModel');
-		return $base_model;
+		return JModelLegacy::getInstance('Base', 'AppsModel');
 	}
 
 	private function getCatID()

--- a/components/com_apps/models/extension.php
+++ b/components/com_apps/models/extension.php
@@ -132,10 +132,12 @@ class AppsModelExtension extends JModelList
 		return $this->_parent;
 	}
 
+	/**
+	 * @return  bool|AppsModelBase
+	 */
 	private function getBaseModel()
 	{
-		$base_model = JModelLegacy::getInstance('Base', 'AppsModel');
-		return $base_model;
+		return JModelLegacy::getInstance('Base', 'AppsModel');
 	}
 
 	private function getCatID()

--- a/jedapps/webinstaller.xml
+++ b/jedapps/webinstaller.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<updates>
+	<update>
+		<name>Installer - Install from Web</name>
+		<description>This plugin offers functionality for the 'Install from Web' tab.</description>
+		<element>webinstaller</element>
+		<type>plugin</type>
+		<folder>installer</folder>
+		<version>1.0.5</version>
+		<client>site</client>
+
+		<infourl title="WebInstaller">http://docs.joomla.org/Install_from_Web</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/install-from-web/1-0-5/plg_webinstaller_3.2v1.0.5.zip</downloadurl>
+		</downloads>
+
+		<maintainer>Efthimios Mavrogeorgiadis</maintainer>
+		<maintainerurl>http://www.joomla.org/</maintainerurl>
+
+		<targetplatform name="joomla" version="3.[23]" />
+	</update>
+	<update>
+		<name>Installer - Install from Web</name>
+		<description>This plugin offers functionality for the 'Install from Web' tab.</description>
+		<element>webinstaller</element>
+		<type>plugin</type>
+		<folder>installer</folder>
+		<version>1.1.1</version>
+		<client>site</client>
+
+		<infourl title="WebInstaller">http://docs.joomla.org/Install_from_Web</infourl>
+		<downloads>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/install-from-web/1-1-1/plg_webinstaller_3.7v1.1.1.zip</downloadurl>
+		</downloads>
+
+		<maintainer>Efthimios Mavrogeorgiadis</maintainer>
+		<maintainerurl>http://www.joomla.org/</maintainerurl>
+
+		<targetplatform name="joomla" version="3.[456789]" />
+	</update>
+</updates>


### PR DESCRIPTION
Summary:

- Adds a new method to the base model to get a configured `JHttp` client
- Refactor caching mechanism to store data in a `com_apps` group versus "global" ungrouped and to only store the response body data versus the full `JHttpResponse` object
- Introduces fallback mechanism to attempt to make a HTTP query if a cache exception is thrown (requires the 3.7 release due to using the new `JCacheException` interface, not a blocker for deploying while the system is on 3.6 because of how PHP handles Exception catch statements)
- Adds error detection in the HTTP request and throws an Exception if the `JHttp` client can't be retrieved, the response code isn't 200, or there is an error running `json_decode()` (which would be indicative of a bad response)
- Adds support for error logging (nothing is configured to log for the `com_apps` category though so it won't be written anywhere)
- Changes JED URLs to use HTTPS scheme
- Minor code style tweaks in modified methods to use project code style standards

In theory this should run against 3.6.5, nothing is dependent on 3.7 except for the noted catch block but as I said that isn't blocking for deploying now.  With these changes, the cache storage should be improved a bit which hopefully makes the underlying system a bit more stable.

Simplest way to test:

- Clone/Download the PR branch and drop the files in your local CMS install
- Discover install com_apps
- Install the Install from Web plugin
- Change `public $appsBaseUrl` in the plugin to point to your local CMS install
- Browse install from web